### PR TITLE
Add Environment Variable Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 lib
 package-lock.json
+.env

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Handle homework through Discord events. Easily manage homework, allowing your cl
 
 ## Setting up
 - Make sure to download [Node JS](https://nodejs.org/en/download/) and then install Typescript by executing `npm i -g typescript` in your terminal/console
-- Configure all of the details within the config file
+- Configure all of the details within the config file **or** set the `TOKEN` environment variable
 - Import the template database file to your "SQL" server
 - Run the `start.sh` file
   - If on windows, execute each line of the file seperate?

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,5 +10,22 @@ export const client = new Client({
 // Start
 import("./handlers/events.js")
 
+// List of token sources
+let token_sources = [
+    config.BotConfig.Token,
+    process.env.TOKEN, // Fallback to environment variable if available
+]
+
+// Get token
+let token = ""
+for (let i = 0; i < token_sources.length; i++) {
+    const source = token_sources[i];
+
+    if (source !== undefined && source !== "") {
+        token = source
+        break
+    }
+}
+
 // Login
-client.login(config.BotConfig.Token)
+client.login(token)


### PR DESCRIPTION
Add some code to fallback to the `TOKEN` environment variable (while also adding support for other sources in a classically overengineered way) instead of the token parameter in `config.ts`.

The reasoning behind this is that `config.ts` is included in the git worktree, so its much too easy to accidentally commit your bot token when developing.