### PR TITLE
Textbook List Command

### DIFF
--- a/src/commands/textbook/list.ts
+++ b/src/commands/textbook/list.ts
@@ -1,0 +1,42 @@
+// Dependencies
+import { ChatInputCommandInteraction, SlashCommandSubcommandBuilder } from "discord.js";
+import { Textbook } from "../../modules/Textbook.js";
+import { DevExecute, getBaseEmbed } from "../../modules/Utilities.js";
+import log from "fancy-log"
+
+// Slash Command
+export const SlashCommand = new SlashCommandSubcommandBuilder()
+    .setName("list")
+    .setDescription("List the available textbooks");
+
+//
+export async function Callback(interaction: ChatInputCommandInteraction) {
+    // Make sure we have the guild
+    const guild = interaction.guild
+    if (!guild) {
+        const Message = "Could not grab guild"
+        throw (new Error(Message))
+    }
+    const guildId = guild.id
+
+    const textbooks = await Textbook.list(guildId)
+
+    DevExecute(log.info, `Got textbooks (${textbooks.length}) from guild ${guildId}`)
+
+    //
+    const embed = getBaseEmbed(interaction.user, "Success")
+        .addFields(
+            ...textbooks.map(textbook => {
+                let formatted = `**ISBN:** ${textbook.ISBN}`
+                formatted += `\n**Link:** ${textbook.Link || "N/A Link"}`
+                return {
+                    name: textbook.Title,
+                    value: formatted,
+                    inline: true,
+                }
+            }),
+        )
+    return interaction.editReply({
+        embeds: [embed]
+    })
+}

--- a/src/commands/textbook/list.ts
+++ b/src/commands/textbook/list.ts
@@ -28,6 +28,7 @@ export async function Callback(interaction: ChatInputCommandInteraction) {
         .addFields(
             ...textbooks.map(textbook => {
                 let formatted = `**ISBN:** ${textbook.ISBN}`
+                formatted += `\n**Subject:** ${textbook.Subject}`
                 formatted += `\n**Link:** ${textbook.Link || "N/A Link"}`
                 return {
                     name: textbook.Title,

--- a/src/modules/Textbook.ts
+++ b/src/modules/Textbook.ts
@@ -75,6 +75,25 @@ export class Textbook {
         }
     }
 
+    static async list(Guild: string, UseCache: boolean = true) {
+        // Logging
+        DevExecute(log.warn, `Attempting to list available textbooks in guild ${Guild}`)
+
+        // Attempt to get it from the cache
+        if (UseCache) {
+            const CachedBooks = TextbookCache.filter(textbook => textbook.Guild == Guild)
+            DevExecute(log.info, `Received textbooks from cache with guild ${Guild}`)
+            return CachedBooks
+        }
+
+        // Query the database for each textbook
+        const [result] = await Database.Connection.query<ITextbookRow[]>("SELECT * FROM `textbook` WHERE `Guild`=?", [Guild])
+
+        // Return the result
+        DevExecute(log.info, `Received textbooks from cache with guild ${Guild}`)
+        return result.map(textbook => new Textbook(textbook))
+    }
+
     // Add a textbook to the database/cache
     static async add(Data: ITextbook, ModifyCache: boolean = true) {
         // Logging


### PR DESCRIPTION
Adds a new command to list the available textbooks while a better `/textbook get` search system is being developed.

Example:
![2022-09-23-160842_808x393_scrot](https://user-images.githubusercontent.com/57148878/191992985-4a0cb868-7713-46fb-b096-d9fcb328034a.png)

