### PR TITLE
Fix Errors in `/homework add`

### DIFF
--- a/src/commands/homework/add.ts
+++ b/src/commands/homework/add.ts
@@ -162,7 +162,10 @@ export async function ModalCallback(interaction: ModalSubmitInteraction) {
 
     // Grab the class code and textbook ISBN
     const ClassCode = await GetClassCode(interaction, guildId)
-    const ISBN = await GetTextbookISBN(interaction, guildId)
+    let ISBN: string | null = null
+    if ((await Textbook.list(guildId)).length != 0) {
+        ISBN = await GetTextbookISBN(interaction, guildId)
+    }
 
     // Vars
     const DueIn = parseInt(strDueIn)

--- a/src/commands/homework/add.ts
+++ b/src/commands/homework/add.ts
@@ -3,7 +3,7 @@ import { ComponentType, ActionRowBuilder, ChatInputCommandInteraction, GuildSche
 import config from "../../config.js";
 import { Class } from "../../modules/Class.js";
 import { Textbook } from "../../modules/Textbook.js";
-import { DevExecute } from "../../modules/Utilities.js";
+import { DevExecute, getBaseEmbed } from "../../modules/Utilities.js";
 import log from "fancy-log"
 
 // Slash Command
@@ -240,6 +240,18 @@ export async function ModalCallback(interaction: ModalSubmitInteraction) {
 
 //
 export async function Callback(interaction: ChatInputCommandInteraction) {
+    // Make sure we have the guild
+    const guild = interaction.guild
+    if (!guild) {
+        const Message = "Could not grab guild"
+        throw (new Error(Message))
+    }
+
+    const classes = await Class.list(guild.id)
+    if (classes.length == 0) {
+        throw (new Error("No classes available, create one with `/class add`!"))
+    }
+
     // Grab the modal
     const modal = GetModal()
 

--- a/src/commands/homework/add.ts
+++ b/src/commands/homework/add.ts
@@ -3,7 +3,7 @@ import { ComponentType, ActionRowBuilder, ChatInputCommandInteraction, GuildSche
 import config from "../../config.js";
 import { Class } from "../../modules/Class.js";
 import { Textbook } from "../../modules/Textbook.js";
-import { DevExecute, getBaseEmbed } from "../../modules/Utilities.js";
+import { DevExecute } from "../../modules/Utilities.js";
 import log from "fancy-log"
 
 // Slash Command


### PR DESCRIPTION
Typically, if there are no textbooks or classes available this would cause the add command to fail with a largely unhelpful error.

This PR does two things:

- Adds a more concise error if no classes are available, prompting the user to create one.
- Skips textbook selection if no textbooks are available, as this would normally cause an error.